### PR TITLE
Link to new specification

### DIFF
--- a/lib/bencode.js
+++ b/lib/bencode.js
@@ -1,5 +1,5 @@
 // BitTorrent metainfo files (.torrent) are encoded using bencoding -
-// https://wiki.theory.org/BitTorrentSpecification#Bencoding
+// https://wiki.theory.org/index.php/BitTorrentSpecification#Bencoding
 //
 // This library provides a few functions for encoding and decoding bencoded
 // inputs.


### PR DESCRIPTION
The Wiki URL has been changed to: https://wiki.theory.org/index.php/BitTorrentSpecification#Bencoding